### PR TITLE
make sure that entry.name is truthy before checking values on it

### DIFF
--- a/asynk/folder_gc.py
+++ b/asynk/folder_gc.py
@@ -160,12 +160,13 @@ class GCContactsFolder(Folder):
             etag = entry.etag
             epd  = entry.deleted
             name = None
-            if entry.name.full_name:
-                name = entry.name.full_name.text
-            elif entry.name.family_name:
-                name = entry.name.family_name.text
-            elif entry.name.given_name:
-                name = entry.name.given_name.text
+            if entry.name:
+                if entry.name.full_name:
+                    name = entry.name.full_name.text
+                elif entry.name.family_name:
+                    name = entry.name.family_name.text
+                elif entry.name.given_name:
+                    name = entry.name.given_name.text
 
             if epd:
                 if olid:


### PR DESCRIPTION
Ran into an issue where some of my contacts from Gmail didn't have "name" set, making everything puke. Just a simple check, I have no idea why that's a thing that's capable of happening from Gmail's side ... 
