### PR TITLE
Ensure em_types is not None before iterating over it

### DIFF
--- a/asynk/contact_cd.py
+++ b/asynk/contact_cd.py
@@ -297,9 +297,9 @@ class CDContact(Contact):
             #     ## We will do something here to save the label as well.
             #     self.add_email_other(em.value)
 
-            em_types = [x.lower() for x in em_types]
 
             if em_types:
+                em_types = [x.lower() for x in em_types]
                 if 'pref' in em_types:
                     self.set_email_prim(em.value)
 


### PR DESCRIPTION
This fixes the following Exception, which occurs when parsing a vcard containing an email address, that doesn't have the `TYPE` field set.
```
[19:00:05.155    ERROR] Error ('NoneType' object is not iterable) parsing vCard object for 00ef8fbe-1319-420c-87ea-cfd074bfee0b
Traceback (most recent call last):
  File "asynk.py", line 323, in <module>
    main()
  File "asynk.py", line 320, in main
    asynk.dispatch()
  File "/home/ben/git/AsynK/asynk/asynk_core.py", line 97, in dispatch
    res = getattr(self, self.get_op())()
  File "/home/ben/git/AsynK/asynk/asynk_core.py", line 388, in op_sync
    sync.prep_lists(self.get_sync_dir())
  File "/home/ben/git/AsynK/asynk/sync.py", line 283, in prep_lists
    return self._prep_lists_2_way(self.get_f1(), self.get_f2())
  File "/home/ben/git/AsynK/asynk/sync.py", line 178, in _prep_lists_2_way
    f1.prep_sync_lists(f2.get_dbid(), f1sl)
  File "/home/ben/git/AsynK/asynk/folder_cd.py", line 66, in prep_sync_lists
    curi  = self.get_itemids(pname, destid)
  File "/home/ben/git/AsynK/asynk/folder_cd.py", line 119, in get_itemids
    self._refresh_contacts()
  File "/home/ben/git/AsynK/asynk/folder_cd.py", line 313, in _refresh_contacts
    cons  = self.find_items(hrefs)
  File "/home/ben/git/AsynK/asynk/folder_cd.py", line 182, in find_items
    cd = CDContact(self, vco=vobject.readOne(vcf.text), itemid=key)
  File "/home/ben/git/AsynK/asynk/contact_cd.py", line 99, in __init__
    self.init_props_from_vco(vco)
  File "/home/ben/git/AsynK/asynk/contact_cd.py", line 179, in init_props_from_vco
    self._snarf_emails_from_vco(vco)
  File "/home/ben/git/AsynK/asynk/contact_cd.py", line 300, in _snarf_emails_from_vco
    em_types = [x.lower() for x in em_types]
TypeError: 'NoneType' object is not iterable
```