### PR TITLE
Add gdata to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ PyOpenSSL
 google-api-python-client
 python-dateutil
 vobject
+gdata


### PR DESCRIPTION
`async/sync.py` imports atom and gdata. Here `atom` means Atom Publishing Protocol
service (AtomPub), which is bundled along with gdata source code, instead of the
framework for creating memory efficient Python objects that is listed in PyPi.
Add it to requirements to avoid user inadvertently installing the wrong atom.